### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,3 +6,4 @@ sentence=Watchy - An Open Source E-Ink SmartWatch by SQFMI
 paragraph=This library contains drivers and code samples for Watchy
 category=Other
 url=https://github.com/sqfmi/Watchy
+depends=GxEPD


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add DS3232RTC as a dependency because this is not a dependency of the library, only the example sketches. However, I think it would also be a reasonable choice to add dependencies as well. So if you want DS3232RTC added, I'll be happy to update this PR.