### PR TITLE
Add .editorconfig file for CRLF endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = crlf


### PR DESCRIPTION
All the source files in the repository are checked in with CRLF line endings. This isn't best practice but fixing it is probably too disruptive at this point. As a next best thing, adding an editor config file tells editors that support it to use CRLF even on non Windows platforms so you don't wind up with a bunch of weird erroneous changes in other commits. 

If we're willing to rip the bandaid off now, I have another branch, https://github.com/DanielCasner/Watchy/tree/line_handling which adds a .gitattributes file and renormalizes all the files.