### PR TITLE
Allow the weather location/units to be set by the user

### DIFF
--- a/examples/WatchFaces/7_SEG/7_SEG.ino
+++ b/examples/WatchFaces/7_SEG/7_SEG.ino
@@ -2,7 +2,11 @@
 
 Watchy7SEG watchy;
 
-void setup(){
+void setup() {
+  // City names with spaces require a +
+  // temp units must be either metric or imperial
+  watchy.setWeatherLocation("New+York", "US", "metric");
+
   watchy.init();
 }
 

--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -612,12 +612,19 @@ void Watchy::drawWatchFace(){
     display.println(currentTime.Minute);    
 }
 
+void Watchy::setWeatherLocation(String city, String countryCode, String tempUnit){
+    currentWeather.city = city;
+    currentWeather.countryCode = countryCode;
+    currentWeather.tempUnit = tempUnit;
+}
+
 weatherData Watchy::getWeatherData(){
     if(weatherIntervalCounter >= WEATHER_UPDATE_INTERVAL){ //only update if WEATHER_UPDATE_INTERVAL has elapsed i.e. 30 minutes
         if(connectWiFi()){//Use Weather API for live data if WiFi is connected
             HTTPClient http;
             http.setConnectTimeout(3000);//3 second max timeout
-            String weatherQueryURL = String(OPENWEATHERMAP_URL) + String(CITY_NAME) + String(",") + String(COUNTRY_CODE) + String("&units=") + String(TEMP_UNIT) + String("&appid=") + String(OPENWEATHERMAP_APIKEY);
+            String weatherQueryURL = String(OPENWEATHERMAP_URL) + String(currentWeather.city) + String(",") + String(currentWeather.countryCode) +
+                    String("&units=") + String(currentWeather.tempUnit) + String("&appid=") + String(OPENWEATHERMAP_APIKEY);
             http.begin(weatherQueryURL.c_str());
             int httpResponseCode = http.GET();
             if(httpResponseCode == 200) {
@@ -634,7 +641,7 @@ weatherData Watchy::getWeatherData(){
             btStop();
         }else{//No WiFi, use RTC Temperature
             uint8_t temperature = RTC.temperature() / 4; //celsius
-            if(strcmp(TEMP_UNIT, "imperial") == 0){
+            if(currentWeather.tempUnit.equals("imperial")){
                 temperature = temperature * 9. / 5. + 32.; //fahrenheit
             }
             currentWeather.temperature = temperature;

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -17,6 +17,9 @@
 typedef struct weatherData{
     int8_t temperature;
     int16_t weatherConditionCode;
+    String city = CITY_NAME;
+    String countryCode = COUNTRY_CODE;
+    String tempUnit = TEMP_UNIT;
 }weatherData;
 
 class Watchy {
@@ -41,6 +44,7 @@ class Watchy {
         void setTime();
         void setupWifi();
         bool connectWiFi();
+        void setWeatherLocation(String city, String country, String units);
         weatherData getWeatherData();
         void updateFWBegin();
 


### PR DESCRIPTION
Update the 7_SEG example to show how it's done.   If watchy.setWeatherLocation() is not used, default to the values in config.h.

Also get/set the user's preferred location data in the weatherData structure, this will allow the location data to be accessible by the watch face itself if desired. 