### PR TITLE
Fix temperature position, closes #52

### DIFF
--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -102,8 +102,8 @@ void Watchy7SEG::drawWeather(){
     display.setFont(&DSEG7_Classic_Regular_39);
     int16_t  x1, y1;
     uint16_t w, h;
-    display.getTextBounds(String(temperature), 100, 150, &x1, &y1, &w, &h);
-    display.setCursor(155 - w, 150);
+    display.getTextBounds(String(temperature), 0, 0, &x1, &y1, &w, &h);
+    display.setCursor(159 - w - x1, 150);
     display.println(temperature);
     display.drawBitmap(165, 110, strcmp(TEMP_UNIT, "metric") == 0 ? celsius : fahrenheit, 26, 20, DARKMODE ? GxEPD_WHITE : GxEPD_BLACK);
     const unsigned char* weatherIcon;

--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -103,7 +103,13 @@ void Watchy7SEG::drawWeather(){
     int16_t  x1, y1;
     uint16_t w, h;
     display.getTextBounds(String(temperature), 0, 0, &x1, &y1, &w, &h);
-    display.setCursor(159 - w - x1, 150);
+    if(159 - w - x1 > 87){
+        display.setCursor(159 - w - x1, 150);
+    }else{
+        display.setFont(&DSEG7_Classic_Bold_25);
+        display.getTextBounds(String(temperature), 0, 0, &x1, &y1, &w, &h);
+        display.setCursor(159 - w - x1, 136);
+    }
     display.println(temperature);
     display.drawBitmap(165, 110, strcmp(TEMP_UNIT, "metric") == 0 ? celsius : fahrenheit, 26, 20, DARKMODE ? GxEPD_WHITE : GxEPD_BLACK);
     const unsigned char* weatherIcon;


### PR DESCRIPTION
The char 1 has a large xOffset:

```c
// bitmapOffset, width, height, xAdvance, xOffset, yOffset
    {     0,   1,   1,   9,    0,    0 }, // ' '
// ...
    {   446,  25,  39,  33,    4,  -39 }, // '0'
    {   568,   5,  35,  33,   24,  -37 }, // '1'
    {   590,  25,  39,  33,    4,  -39 }, // '2'
```

And getTextBounds does not count the offset, only “real” pixels. That’s why w does not seems correct.

To solve this, x1 also needs to be taken (and I added 4 the '2' xOffset to get to the original position).