### PR TITLE
Added ntpTimeSync to most watch faces

### DIFF
--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -22,6 +22,47 @@ void Watchy7SEG::drawWatchFace(){
     if(BLE_CONFIGURED){
         display.drawBitmap(100, 75, bluetooth, 13, 21, DARKMODE ? GxEPD_WHITE : GxEPD_BLACK);
     }
+    syncNtpTime();
+}
+
+void Watchy7SEG::syncNtpTime(){
+    const char* ntpServer = "pool.ntp.org";
+    const long gmtOffset_sec = -21600; // set time zone to central standard time
+                                        // ie UTC -6 * 60 * 60 = -21600
+    const int daylightOffset_sec = 3600;// if observing Daylight saving time 3600 otherwise 0
+    struct tm timeinfo;
+
+    // Watchy updates every minute but we really only need to sync a few times a day
+    if(currentTime.Hour % 8 == 0 && currentTime.Minute == 0){
+      //only run this at midnight,8am and 4pm
+      // three times a day to correct time drift.
+
+      //make sure WiFi is connected
+      if(Watchy::connectWiFi()){
+          // wifi connected so proceed to get NTP time
+          
+          //get NTP Time
+          configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+          getLocalTime(&timeinfo);
+
+          // convert NTP time into proper format
+          tmElements_t tm;
+          tm.Month = timeinfo.tm_mon + 1;// 0-11 based month so we have to add 1
+          tm.Day = timeinfo.tm_mday;
+          tm.Year = timeinfo.tm_year + 1900 - YEAR_OFFSET;//offset from 1970, since year is stored in uint8_t
+          tm.Hour = timeinfo.tm_hour;
+          tm.Minute = timeinfo.tm_min;
+          tm.Second = timeinfo.tm_sec;
+          time_t t = makeTime(tm);
+          
+          //set the RTC time to the NTP time
+          RTC.set(t);
+
+          // shut down the radio to save power
+          WiFi.mode(WIFI_OFF);
+          btStop();
+      }
+    }
 }
 
 void Watchy7SEG::drawTime(){

--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.h
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.h
@@ -12,6 +12,7 @@ class Watchy7SEG : public Watchy{
     public:
         Watchy7SEG();
         void drawWatchFace();
+        void syncNtpTime();
         void drawTime();
         void drawDate();
         void drawSteps();

--- a/examples/WatchFaces/DOS/Watchy_DOS.cpp
+++ b/examples/WatchFaces/DOS/Watchy_DOS.cpp
@@ -30,4 +30,46 @@ void WatchyDOS::drawWatchFace(){
     display.println("  2048 bytes free");
     display.println(" ");
     display.println("<C:\\>esptool");
+
+    syncNtpTime();
+}
+
+void Watchy7SEG::syncNtpTime(){
+    const char* ntpServer = "pool.ntp.org";
+    const long gmtOffset_sec = -21600; // set time zone to central standard time
+                                        // ie UTC -6 * 60 * 60 = -21600
+    const int daylightOffset_sec = 3600;// if observing Daylight saving time 3600 otherwise 0
+    struct tm timeinfo;
+
+    // Watchy updates every minute but we really only need to sync a few times a day
+    if(currentTime.Hour % 8 == 0 && currentTime.Minute == 0){
+      //only run this at midnight,8am and 4pm
+      // three times a day to correct time drift.
+
+      //make sure WiFi is connected
+      if(Watchy::connectWiFi()){
+          // wifi connected so proceed to get NTP time
+          
+          //get NTP Time
+          configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+          getLocalTime(&timeinfo);
+
+          // convert NTP time into proper format
+          tmElements_t tm;
+          tm.Month = timeinfo.tm_mon + 1;// 0-11 based month so we have to add 1
+          tm.Day = timeinfo.tm_mday;
+          tm.Year = timeinfo.tm_year + 1900 - YEAR_OFFSET;//offset from 1970, since year is stored in uint8_t
+          tm.Hour = timeinfo.tm_hour;
+          tm.Minute = timeinfo.tm_min;
+          tm.Second = timeinfo.tm_sec;
+          time_t t = makeTime(tm);
+          
+          //set the RTC time to the NTP time
+          RTC.set(t);
+
+          // shut down the radio to save power
+          WiFi.mode(WIFI_OFF);
+          btStop();
+      }
+    }
 }

--- a/examples/WatchFaces/DOS/Watchy_DOS.h
+++ b/examples/WatchFaces/DOS/Watchy_DOS.h
@@ -8,6 +8,7 @@ class WatchyDOS : public Watchy{
     public:
         WatchyDOS();
         void drawWatchFace();
+        void syncNtpTime();
 };
 
 #endif

--- a/examples/WatchFaces/MacPaint/Watchy_MacPaint.cpp
+++ b/examples/WatchFaces/MacPaint/Watchy_MacPaint.cpp
@@ -18,4 +18,46 @@ void WatchyMacPaint::drawWatchFace(){
     //Minute
     display.drawBitmap(115, 70, numbers[currentTime.Minute/10], 38, 50, GxEPD_BLACK); //first digit
     display.drawBitmap(153, 70, numbers[currentTime.Minute%10], 38, 50, GxEPD_BLACK); //second digit
+
+    syncNtpTime();
+}
+
+void Watchy7SEG::syncNtpTime(){
+    const char* ntpServer = "pool.ntp.org";
+    const long gmtOffset_sec = -21600; // set time zone to central standard time
+                                        // ie UTC -6 * 60 * 60 = -21600
+    const int daylightOffset_sec = 3600;// if observing Daylight saving time 3600 otherwise 0
+    struct tm timeinfo;
+
+    // Watchy updates every minute but we really only need to sync a few times a day
+    if(currentTime.Hour % 8 == 0 && currentTime.Minute == 0){
+      //only run this at midnight,8am and 4pm
+      // three times a day to correct time drift.
+
+      //make sure WiFi is connected
+      if(Watchy::connectWiFi()){
+          // wifi connected so proceed to get NTP time
+          
+          //get NTP Time
+          configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+          getLocalTime(&timeinfo);
+
+          // convert NTP time into proper format
+          tmElements_t tm;
+          tm.Month = timeinfo.tm_mon + 1;// 0-11 based month so we have to add 1
+          tm.Day = timeinfo.tm_mday;
+          tm.Year = timeinfo.tm_year + 1900 - YEAR_OFFSET;//offset from 1970, since year is stored in uint8_t
+          tm.Hour = timeinfo.tm_hour;
+          tm.Minute = timeinfo.tm_min;
+          tm.Second = timeinfo.tm_sec;
+          time_t t = makeTime(tm);
+          
+          //set the RTC time to the NTP time
+          RTC.set(t);
+
+          // shut down the radio to save power
+          WiFi.mode(WIFI_OFF);
+          btStop();
+      }
+    }
 }

--- a/examples/WatchFaces/MacPaint/Watchy_MacPaint.h
+++ b/examples/WatchFaces/MacPaint/Watchy_MacPaint.h
@@ -8,6 +8,7 @@ class WatchyMacPaint : public Watchy{
     public:
         WatchyMacPaint();
         void drawWatchFace();
+        void syncNtpTime();
 };
 
 #endif

--- a/examples/WatchFaces/Pokemon/Watchy_Pokemon.cpp
+++ b/examples/WatchFaces/Pokemon/Watchy_Pokemon.cpp
@@ -17,4 +17,46 @@ void WatchyPokemon::drawWatchFace(){
         display.print('0');
     }    
     display.print(currentTime.Minute);
+
+    syncNtpTime();
+}
+
+void Watchy7SEG::syncNtpTime(){
+    const char* ntpServer = "pool.ntp.org";
+    const long gmtOffset_sec = -21600; // set time zone to central standard time
+                                        // ie UTC -6 * 60 * 60 = -21600
+    const int daylightOffset_sec = 3600;// if observing Daylight saving time 3600 otherwise 0
+    struct tm timeinfo;
+
+    // Watchy updates every minute but we really only need to sync a few times a day
+    if(currentTime.Hour % 8 == 0 && currentTime.Minute == 0){
+      //only run this at midnight,8am and 4pm
+      // three times a day to correct time drift.
+
+      //make sure WiFi is connected
+      if(Watchy::connectWiFi()){
+          // wifi connected so proceed to get NTP time
+          
+          //get NTP Time
+          configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+          getLocalTime(&timeinfo);
+
+          // convert NTP time into proper format
+          tmElements_t tm;
+          tm.Month = timeinfo.tm_mon + 1;// 0-11 based month so we have to add 1
+          tm.Day = timeinfo.tm_mday;
+          tm.Year = timeinfo.tm_year + 1900 - YEAR_OFFSET;//offset from 1970, since year is stored in uint8_t
+          tm.Hour = timeinfo.tm_hour;
+          tm.Minute = timeinfo.tm_min;
+          tm.Second = timeinfo.tm_sec;
+          time_t t = makeTime(tm);
+          
+          //set the RTC time to the NTP time
+          RTC.set(t);
+
+          // shut down the radio to save power
+          WiFi.mode(WIFI_OFF);
+          btStop();
+      }
+    }
 }

--- a/examples/WatchFaces/Pokemon/Watchy_Pokemon.h
+++ b/examples/WatchFaces/Pokemon/Watchy_Pokemon.h
@@ -8,6 +8,7 @@ class WatchyPokemon : public Watchy{
     public:
         WatchyPokemon();
         void drawWatchFace();
+        void syncNtpTime();
 };
 
 #endif

--- a/examples/WatchFaces/Tetris/Watchy_Tetris.cpp
+++ b/examples/WatchFaces/Tetris/Watchy_Tetris.cpp
@@ -15,4 +15,46 @@ void WatchyTetris::drawWatchFace(){
     //Minute
     display.drawBitmap(25, 110, tetris_nums[currentTime.Minute/10], 40, 60, GxEPD_BLACK); //first digit
     display.drawBitmap(75, 110, tetris_nums[currentTime.Minute%10], 40, 60, GxEPD_BLACK); //second digit
+
+    syncNtpTime();
+}
+
+void Watchy7SEG::syncNtpTime(){
+    const char* ntpServer = "pool.ntp.org";
+    const long gmtOffset_sec = -21600; // set time zone to central standard time
+                                        // ie UTC -6 * 60 * 60 = -21600
+    const int daylightOffset_sec = 3600;// if observing Daylight saving time 3600 otherwise 0
+    struct tm timeinfo;
+
+    // Watchy updates every minute but we really only need to sync a few times a day
+    if(currentTime.Hour % 8 == 0 && currentTime.Minute == 0){
+      //only run this at midnight,8am and 4pm
+      // three times a day to correct time drift.
+
+      //make sure WiFi is connected
+      if(Watchy::connectWiFi()){
+          // wifi connected so proceed to get NTP time
+          
+          //get NTP Time
+          configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+          getLocalTime(&timeinfo);
+
+          // convert NTP time into proper format
+          tmElements_t tm;
+          tm.Month = timeinfo.tm_mon + 1;// 0-11 based month so we have to add 1
+          tm.Day = timeinfo.tm_mday;
+          tm.Year = timeinfo.tm_year + 1900 - YEAR_OFFSET;//offset from 1970, since year is stored in uint8_t
+          tm.Hour = timeinfo.tm_hour;
+          tm.Minute = timeinfo.tm_min;
+          tm.Second = timeinfo.tm_sec;
+          time_t t = makeTime(tm);
+          
+          //set the RTC time to the NTP time
+          RTC.set(t);
+
+          // shut down the radio to save power
+          WiFi.mode(WIFI_OFF);
+          btStop();
+      }
+    }
 }

--- a/examples/WatchFaces/Tetris/Watchy_Tetris.h
+++ b/examples/WatchFaces/Tetris/Watchy_Tetris.h
@@ -8,6 +8,7 @@ class WatchyTetris : public Watchy{
     public:
         WatchyTetris();
         void drawWatchFace();
+        void syncNtpTime();
 };
 
 #endif


### PR DESCRIPTION
I was unable to add it to the watch faces "basic" and "StarryHorizon" because of their different structure.
The "ntpTimeSync()" Code was provided by @OverThinker.