### PR TITLE
Change to more accurate ADC call

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -648,7 +648,8 @@ weatherData Watchy::getWeatherData(){
 }
 
 float Watchy::getBatteryVoltage(){
-    return analogRead(ADC_PIN) / 4096.0 * 7.23;
+    // Battery voltage goes through a 1/2 divider.
+    return analogReadMilliVolts(ADC_PIN) / 1000.0f * 2.0f;
 }
 
 uint16_t Watchy::_readRegister(uint8_t address, uint8_t reg, uint8_t *data, uint16_t len)


### PR DESCRIPTION
Was there a reason to use this equation for the ADC? Using the milliVolts version seems to give more accurate values. At full charge, the original give ~4.53 V and the new code give ~4.30 V.