### PR TITLE
Added variable HOUR_12_24 to config.h

### DIFF
--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -27,10 +27,10 @@ void Watchy7SEG::drawWatchFace(){
 void Watchy7SEG::drawTime(){
     display.setFont(&DSEG7_Classic_Bold_53);
     display.setCursor(5, 53+5);
-    if(currentTime.Hour < 10){
+    if(currentTime.Hour % HOUR_12_24 < 10){
         display.print("0");
     }
-    display.print(currentTime.Hour);
+    display.print(currentTime.Hour % HOUR_12_24);
     display.print(":");
     if(currentTime.Minute < 10){
         display.print("0");

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,7 @@
 #define SET_MONTH 3
 #define SET_DAY 4
 #define YEAR_OFFSET 1970
+#define HOUR_12_24 24
 //BLE OTA
 #define BLE_DEVICE_NAME "Watchy BLE OTA"
 #define WATCHFACE_NAME "Watchy 7 Segment"


### PR DESCRIPTION
Added a simple option to set the watch to a 12-hour display, via a variable set in config.h.  Added code showing intended use of this variable in the 7_SEG example, note it only updates the display not the stored time.  Perhaps in the future this option could be set from the "Set Time" menu or similar instead of config.h?