### PR TITLE
7_SEG: Fair fixing of wednesday display issue

### DIFF
--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -51,6 +51,10 @@ void Watchy7SEG::drawDate(){
     uint16_t w, h;
 
     String dayOfWeek = dayStr(currentTime.Wday);
+    if (currentTime.Wday == 4)
+    {
+        dayOfWeek = "Wednesdy";
+    }
     display.getTextBounds(dayOfWeek, 5, 85, &x1, &y1, &w, &h);
     display.setCursor(85 - w, 85);
     display.println(dayOfWeek);


### PR DESCRIPTION
The "W" of wednesday was cutting off if using the 7_SEG watchface. I randomly found a tolerable fix and included it.

Thank you LeeHolmes
Spotted at https://github.com/LeeHolmes/watchysim