### PR TITLE
Optimize display update

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -10,6 +10,7 @@ RTC_DATA_ATTR bool WIFI_CONFIGURED;
 RTC_DATA_ATTR bool BLE_CONFIGURED;
 RTC_DATA_ATTR weatherData currentWeather;
 RTC_DATA_ATTR int weatherIntervalCounter = WEATHER_UPDATE_INTERVAL;
+RTC_DATA_ATTR bool displayFullInit = true;
 
 Watchy::Watchy(){} //constructor
 
@@ -18,6 +19,11 @@ void Watchy::init(String datetime){
     wakeup_reason = esp_sleep_get_wakeup_cause(); //get wake up reason
     Wire.begin(SDA, SCL); //init i2c
     RTC.init();
+
+    // Init the display here for all cases, if unused, it will do nothing
+    display.init(0, displayFullInit, 10, true); // 10ms by spec, and fast pulldown reset
+    display.epd2.setBusyCallback(displayBusyCallback);
+
     switch (wakeup_reason)
     {
         case ESP_SLEEP_WAKEUP_EXT0: //RTC Alarm
@@ -40,7 +46,15 @@ void Watchy::init(String datetime){
     deepSleep();
 }
 
+void Watchy::displayBusyCallback(const void*){
+  gpio_wakeup_enable((gpio_num_t)BUSY, GPIO_INTR_LOW_LEVEL);
+  esp_sleep_enable_gpio_wakeup();
+  esp_light_sleep_start();
+}
+
 void Watchy::deepSleep(){
+  display.hibernate();
+  displayFullInit = false; // Notify not to init it again
   esp_sleep_enable_ext0_wakeup(RTC_PIN, 0); //enable deep sleep wake on RTC interrupt
   esp_sleep_enable_ext1_wakeup(BTN_PIN_MASK, ESP_EXT1_WAKEUP_ANY_HIGH); //enable deep sleep wake on button press
   esp_deep_sleep_start();
@@ -192,11 +206,9 @@ void Watchy::handleButtonPress(){
           }
       }
   }
-  display.hibernate();    
 }
 
 void Watchy::showMenu(byte menuIndex, bool partialRefresh){
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);
@@ -221,7 +233,6 @@ void Watchy::showMenu(byte menuIndex, bool partialRefresh){
     }
 
     display.display(partialRefresh);
-    //display.hibernate();
 
     guiState = MAIN_MENU_STATE;    
 }
@@ -256,7 +267,6 @@ void Watchy::showFastMenu(byte menuIndex){
 }
 
 void Watchy::showBattery(){
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);
@@ -268,13 +278,11 @@ void Watchy::showBattery(){
     display.print(voltage);
     display.println("V");
     display.display(false); //full refresh
-    display.hibernate();
 
     guiState = APP_STATE;      
 }
 
 void Watchy::showBuzz(){
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);
@@ -282,7 +290,6 @@ void Watchy::showBuzz(){
     display.setCursor(70, 80);
     display.println("Buzz!");
     display.display(false); //full refresh
-    display.hibernate();
     vibMotor();
     showMenu(menuIndex, false);    
 }
@@ -318,7 +325,6 @@ void Watchy::setTime(){
     pinMode(MENU_BTN_PIN, INPUT);  
     pinMode(BACK_BTN_PIN, INPUT);  
 
-    display.init(0, true); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
 
     while(1){
@@ -441,8 +447,6 @@ void Watchy::setTime(){
     display.display(true); //partial refresh
     }
 
-    display.hibernate();
-
     tmElements_t tm;
     tm.Month = month;
     tm.Day = day;
@@ -458,7 +462,6 @@ void Watchy::setTime(){
 }
 
 void Watchy::showAccelerometer(){
-    display.init(0, true); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);
@@ -529,11 +532,9 @@ void Watchy::showAccelerometer(){
 }
 
 void Watchy::showWatchFace(bool partialRefresh){
-  display.init(0, false); //_initial_refresh to false to prevent full update on init
   display.setFullWindow();
   drawWatchFace();
   display.display(partialRefresh); //partial refresh
-  display.hibernate();
   guiState = WATCHFACE_STATE;
 }
 
@@ -716,28 +717,19 @@ void Watchy::setupWifi(){
   wifiManager.resetSettings();
   wifiManager.setTimeout(WIFI_AP_TIMEOUT);
   wifiManager.setAPCallback(_configModeCallback);
+  display.setFullWindow();
+  display.fillScreen(GxEPD_BLACK);
+  display.setFont(&FreeMonoBold9pt7b);
+  display.setTextColor(GxEPD_WHITE);
   if(!wifiManager.autoConnect(WIFI_AP_SSID)) {//WiFi setup failed
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
-    display.setFullWindow();
-    display.fillScreen(GxEPD_BLACK);
-    display.setFont(&FreeMonoBold9pt7b);
-    display.setTextColor(GxEPD_WHITE);
     display.setCursor(0, 30);
     display.println("Setup failed &");
     display.println("timed out!");
-    display.display(false); //full refresh
-    display.hibernate();
   }else{
-    display.init(0, false);//_initial_refresh to false to prevent full update on init
-    display.setFullWindow();
-    display.fillScreen(GxEPD_BLACK);
-    display.setFont(&FreeMonoBold9pt7b);
-    display.setTextColor(GxEPD_WHITE);
     display.println("Connected to");
     display.println(WiFi.SSID());
-    display.display(false);//full refresh
-    display.hibernate();
   }
+  display.display(false); //full refresh
   //turn off radios
   WiFi.mode(WIFI_OFF);
   btStop();
@@ -746,7 +738,6 @@ void Watchy::setupWifi(){
 }
 
 void Watchy::_configModeCallback (WiFiManager *myWiFiManager) {
-  display.init(0, false); //_initial_refresh to false to prevent full update on init
   display.setFullWindow();
   display.fillScreen(GxEPD_BLACK);
   display.setFont(&FreeMonoBold9pt7b);
@@ -758,7 +749,6 @@ void Watchy::_configModeCallback (WiFiManager *myWiFiManager) {
   display.print("IP: ");
   display.println(WiFi.softAPIP());
   display.display(false); //full refresh
-  display.hibernate();
 }
 
 bool Watchy::connectWiFi(){
@@ -778,7 +768,6 @@ bool Watchy::connectWiFi(){
 }
 
 void Watchy::showUpdateFW(){
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);
@@ -794,13 +783,11 @@ void Watchy::showUpdateFW(){
     display.println(" ");
     display.println("Keep USB powered");
     display.display(false); //full refresh
-    display.hibernate();
 
     guiState = FW_UPDATE_STATE;  
 }
 
 void Watchy::updateFWBegin(){
-    display.init(0, false); //_initial_refresh to false to prevent full update on init
     display.setFullWindow();
     display.fillScreen(GxEPD_BLACK);
     display.setFont(&FreeMonoBold9pt7b);

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -28,6 +28,7 @@ class Watchy {
         Watchy();
         void init(String datetime = "");
         void deepSleep();
+        static void displayBusyCallback(const void*);
         float getBatteryVoltage();
         void vibMotor(uint8_t intervalMs = 100, uint8_t length = 20);
 


### PR DESCRIPTION
* Display hibernate should only be called before deep sleep
* Display init should only be called once and notify the last init state
* Set up init properly with 10ms reset and pulldown_rst
* Use GxEDP2 1.4.0 library new busy callback
  to trigger a lightsleep in the mean time
  Saving 650ms of CPU time per update, (16mAs/minute)
  That is -6.5mAh per day savings