### PR TITLE
Set all pins to INPUT before deep sleep

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -41,6 +41,10 @@ void Watchy::init(String datetime){
 }
 
 void Watchy::deepSleep(){
+  // Set all pins to input to avoid power leaking out
+  for(int i=0; i<48; i++) {
+    pinMode(i, INPUT);
+  }
   esp_sleep_enable_ext0_wakeup(RTC_PIN, 0); //enable deep sleep wake on RTC interrupt
   esp_sleep_enable_ext1_wakeup(BTN_PIN_MASK, ESP_EXT1_WAKEUP_ANY_HIGH); //enable deep sleep wake on button press
   esp_deep_sleep_start();


### PR DESCRIPTION
* Some pins otherwise are left as output
  And their value is kept in deep sleep
  This can cause power usage in deep sleep
* From my measurements 0.13mA
  Or, 3mAh / day extra usage