### PR TITLE
Year offsets no longer necessary.

### DIFF
--- a/src/WatchyRTC.h
+++ b/src/WatchyRTC.h
@@ -8,8 +8,6 @@
 #define PCF8563 1
 #define RTC_DS_ADDR 0x68
 #define RTC_PCF_ADDR 0x51
-#define YEAR_OFFSET_DS 1970
-#define YEAR_OFFSET_PCF 2000
 
 class WatchyRTC {
     public:

--- a/src/WatchyRTC.h
+++ b/src/WatchyRTC.h
@@ -8,6 +8,11 @@
 #define PCF8563 1
 #define RTC_DS_ADDR 0x68
 #define RTC_PCF_ADDR 0x51
+#define RTC_YEAR_OFFSET 1900			// Use for calculation to display year properly.
+#define RTC_CENTURY_OFFSET 100			// Short Year offset.
+#define RTC_1900TO1970 2208988800UL		// Subtract from NTP to get Epoch.
+#define RTC_1970TO2000 946684800UL		// Subtract from Epoch to get Y2k.
+#define RTC_1900TO2000 (RTC_1900TO1970 + RTC_1970TO2000)	// Subtract from NTP to get Y2k.
 
 class WatchyRTC {
     public:
@@ -22,7 +27,6 @@ class WatchyRTC {
         void read(tmElements_t &tm);
         void set(tmElements_t tm);
         uint8_t temperature();
-        time_t NTPCorrection(time_t FromNTP);
     private:
         void _DSConfig(String datetime);
         void _PCFConfig(String datetime);

--- a/src/WatchyRTC.h
+++ b/src/WatchyRTC.h
@@ -22,6 +22,7 @@ class WatchyRTC {
         void read(tmElements_t &tm);
         void set(tmElements_t tm);
         uint8_t temperature();
+        time_t NTPCorrection(time_t FromNTP);
     private:
         void _DSConfig(String datetime);
         void _PCFConfig(String datetime);


### PR DESCRIPTION
This goes along with the other pull request for WatchyRTC.cpp.