### PR TITLE
Fixes issue #129 - stops writing over previous text

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -724,7 +724,6 @@ void Watchy::setupWifi(){
   display.setFont(&FreeMonoBold9pt7b);
   display.setTextColor(GxEPD_WHITE);
   if(!wifiManager.autoConnect(WIFI_AP_SSID)) {//WiFi setup failed
-    display.setCursor(0, 30);
     display.println("Setup failed &");
     display.println("timed out!");
   }else{


### PR DESCRIPTION
See description in issue #129 - the previous text isn't cleared but we are using `display.setCursor(0, 30);` to start at the top left corner writing.