### PR TITLE
Dynamic Weather setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ avr-toolchain-*.zip
 manifest.mf
 nbbuild.xml
 nbproject
+.vscode

--- a/examples/WatchFaces/7_SEG/7_SEG.ino
+++ b/examples/WatchFaces/7_SEG/7_SEG.ino
@@ -3,10 +3,9 @@
 Watchy7SEG watchy;
 
 void setup(){
+  // initialise weather to New York City, Celsius temperature, 30-minute updates, English language, SQFMI's API key
+  watchy.setupWeather(5128581, true, 30, String("en"), String("f058fe1cad2afe8e2ddc5d063a64cecb") );
   watchy.init();
 }
 
 void loop(){}
-
-
-

--- a/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
+++ b/examples/WatchFaces/7_SEG/Watchy_7_SEG.cpp
@@ -124,7 +124,7 @@ void Watchy7SEG::drawWeather(){
         display.setCursor(159 - w - x1, 136);
     }
     display.println(temperature);
-    display.drawBitmap(165, 110, strcmp(TEMP_UNIT, "metric") == 0 ? celsius : fahrenheit, 26, 20, DARKMODE ? GxEPD_WHITE : GxEPD_BLACK);
+    display.drawBitmap(165, 110, weatherCelsius == true ? celsius : fahrenheit, 26, 20, DARKMODE ? GxEPD_WHITE : GxEPD_BLACK);
     const unsigned char* weatherIcon;
 
     //https://openweathermap.org/weather-conditions

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -15,8 +15,9 @@
 #include "config.h"
 
 typedef struct weatherData{
-    int8_t temperature;
+    int8_t  temperature;
     int16_t weatherConditionCode;
+    String  weatherDescription;
 }weatherData;
 
 class Watchy {
@@ -47,12 +48,20 @@ class Watchy {
 
         void showWatchFace(bool partialRefresh);
         virtual void drawWatchFace(); //override this method for different watch faces
-
+        void setupWeather( uint32_t city, bool celsius, uint16_t updateInterval, String lang, String apikey );
+        uint8_t  getAmbientTemp();
+        bool     weatherCelsius = true;
     private:
         void _bmaConfig();
         static void _configModeCallback(WiFiManager *myWiFiManager);
         static uint16_t _readRegister(uint8_t address, uint8_t reg, uint8_t *data, uint16_t len);
         static uint16_t _writeRegister(uint8_t address, uint8_t reg, uint8_t *data, uint16_t len);
+        uint16_t weatherInterval;
+        uint32_t weatherCity;
+        String   weatherAPIKey;
+        String   weatherLang;
+        bool     weatherInit = false;
+        uint16_t weatherIntervalCounter = 0;
 };
 
 extern RTC_DATA_ATTR int guiState;

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -50,18 +50,11 @@ class Watchy {
         virtual void drawWatchFace(); //override this method for different watch faces
         void setupWeather( uint32_t city, bool celsius, uint16_t updateInterval, String lang, String apikey );
         uint8_t  getAmbientTemp();
-        bool     weatherCelsius = true;
     private:
         void _bmaConfig();
         static void _configModeCallback(WiFiManager *myWiFiManager);
         static uint16_t _readRegister(uint8_t address, uint8_t reg, uint8_t *data, uint16_t len);
         static uint16_t _writeRegister(uint8_t address, uint8_t reg, uint8_t *data, uint16_t len);
-        uint16_t weatherInterval;
-        uint32_t weatherCity;
-        String   weatherAPIKey;
-        String   weatherLang;
-        bool     weatherInit = false;
-        uint16_t weatherIntervalCounter = 0;
 };
 
 extern RTC_DATA_ATTR int guiState;
@@ -69,5 +62,11 @@ extern RTC_DATA_ATTR int menuIndex;
 extern RTC_DATA_ATTR BMA423 sensor;
 extern RTC_DATA_ATTR bool WIFI_CONFIGURED;
 extern RTC_DATA_ATTR bool BLE_CONFIGURED;
+extern RTC_DATA_ATTR bool weatherCelsius;
+extern RTC_DATA_ATTR String weatherLang;
+extern RTC_DATA_ATTR String weatherAPIKey;
+extern RTC_DATA_ATTR uint16_t weatherIntervalCounter;
+extern RTC_DATA_ATTR uint32_t weatherCity;
+extern RTC_DATA_ATTR uint16_t weatherInterval;
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -25,13 +25,6 @@
 //display
 #define DISPLAY_WIDTH 200
 #define DISPLAY_HEIGHT 200
-//weather api
-#define CITY_NAME "NEW+YORK" //if your city name has a space, replace with '+'
-#define COUNTRY_CODE "US"
-#define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?q="
-#define TEMP_UNIT "metric" //use "imperial" for Fahrenheit"
-#define WEATHER_UPDATE_INTERVAL 30 //minutes
 //wifi
 #define WIFI_AP_TIMEOUT 60
 #define WIFI_AP_SSID "Watchy AP"


### PR DESCRIPTION
### Summary

This is my first PR to the project, and it's a bit big. The contributing instructions say to make branches off of `dev` and then submit. But `dev` appears to be 2 months behind `master` and lacks the NTP changes. I'm not sure what to do there, so I've submitted this PR against the master branch.

At a high level, everything related to weather that was in `config.h` has been removed from there and made more dynamic.

### setupWeather()

New `setupWeather()` method initialises the weather subsystem with things like Celsius/Fahrenheit, API key, and city ID to pull weather for.  This allows changing the city at run-time. For example it could be possible to choose different cities off a menu, or even enter the city ID at run time (if you want to enter 7-digit numbers using a few buttons). This helps address #50 by switching from text-based search to unique City ID.

A new public member `weatherCelsius` is a `bool` that stores whether the weather should be returned in Celsius or not. That preference can now be referred to in other parts of the code. This would allow the choice of Fahrenheit/Celsius to change. E.g., it could become selectable off a menu (haven't done that yet).

This method can be used by watch faces like this:

```
WatchFace W;

void setup() {
  W.setupWeather( 4751935, false, 30, String("en"), String ("abcdefg") );
  W.init();
}
```

### Other Changes

New `getAmbientTemp()` method that calls the sensor's `readTemperature()` and then looks at the current preference for Fahrenheit/Celsius and converts if necessary.

Modified `getWeatherData()` now does a few things differently:
- If there is an HTTP error, it returns ambient temperature from the sensor and sets the description to "Ambient". (Previously it did nothing)
- The `weatherData` struct now has an additional `String` member that contains the one-word description of the weather provided by openweathermap. `getWeatherData()` reads it from the JSON payload and adds it to the `struct`
- If the weather subsystem has not been initialised, `setupWeather()` is called with some sane defaults.

All code is documented in a format that would be recognised by Doxygen.

### Impact

Faces that did not call `setupWeather()` before will not break. The example `7_SEG` face referred directly to `TEMP_UNIT` from `config.h` and so it would fail to compile after this change is applied. I made small modifications to it to allow it to compile and to demonstrate how a face can call `setupWeather()`.