### PR TITLE
Tag lib version with 'dev' for the dev branch and tighten up the

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -279,7 +279,7 @@ void Watchy::showAbout(){
     display.setTextColor(GxEPD_WHITE);
     display.setCursor(0, 20);
 
-    display.print("Lib Ver: v");
+    display.print("LibVer: ");
     display.println(WATCHY_LIB_VER);
 
     const char *RTC_HW[3] = { "<UNKNOWN>", "DS3231", "PCF8563" };

--- a/src/config.h
+++ b/src/config.h
@@ -51,5 +51,5 @@
 #define HARDWARE_VERSION_MAJOR 1
 #define HARDWARE_VERSION_MINOR 0
 //Versioning
-#define WATCHY_LIB_VER "1.3.3"
+#define WATCHY_LIB_VER "1.3.3dev"
 #endif


### PR DESCRIPTION
About menu to allow for longer lib version strings.  This makes it easier to tell which branch the firmware was built from.