### PR TITLE
add basic button support

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -114,6 +114,7 @@ void Watchy::handleButtonPress() {
     } else if (guiState == FW_UPDATE_STATE) {
       showMenu(menuIndex, false); // exit to menu if already in app
     } else if (guiState == WATCHFACE_STATE) {
+      button1();
       return;
     }
   }
@@ -126,6 +127,7 @@ void Watchy::handleButtonPress() {
       }
       showMenu(menuIndex, true);
     } else if (guiState == WATCHFACE_STATE) {
+      button2();
       return;
     }
   }
@@ -138,6 +140,7 @@ void Watchy::handleButtonPress() {
       }
       showMenu(menuIndex, true);
     } else if (guiState == WATCHFACE_STATE) {
+      button3();
       return;
     }
   }
@@ -578,6 +581,17 @@ void Watchy::drawWatchFace() {
   }
   display.println(currentTime.Minute);
 }
+
+void Watchy::button1()
+{
+}
+void Watchy::button2()
+{
+}
+void Watchy::button3()
+{
+}
+
 
 weatherData Watchy::getWeatherData() {
   return getWeatherData(settings.cityID, settings.weatherUnit,

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -73,6 +73,9 @@ public:
   void showWatchFace(bool partialRefresh);
   virtual void drawWatchFace(); // override this method for different watch
                                 // faces
+  virtual void button1(); // override these methods to handle different non-menu button presses
+  virtual void button2();
+  virtual void button3();
 
 private:
   void _bmaConfig();


### PR DESCRIPTION
I added basic support for handling three of the four buttons when the watch is in Watchface mode.

This can be an example for others, or I'm happy to modify to make it part of the core base, as it is nice to use the buttons to change settings on some watchfaces.

Enjoy! Thanks for the fun product.