### PR TITLE
Allow watch faces to implement custom handleButtonPress functions

### DIFF
--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -52,7 +52,7 @@ public:
   float getBatteryVoltage();
   void vibMotor(uint8_t intervalMs = 100, uint8_t length = 20);
 
-  void handleButtonPress();
+  virtual void handleButtonPress();
   void showMenu(byte menuIndex, bool partialRefresh);
   void showFastMenu(byte menuIndex);
   void showAbout();


### PR DESCRIPTION
This PR allows users to implement custom implementations for `handleButtonPress`!

For example, with the changes in this PR, I could do:

```cpp
void WatchyKeen::handleButtonPress() {
  pinMode(VIB_MOTOR_PIN, OUTPUT);
  
  digitalWrite(VIB_MOTOR_PIN, HIGH);
  delay(50);
  digitalWrite(VIB_MOTOR_PIN, LOW);

  Watchy::handleButtonPress();
}
```

This example gives a "tactile" effect for every button press by doing two things:

- Vibrates the motor for 50 ms
- Calls the original `handleButtonPress` [from the Watchy library](https://github.com/sqfmi/Watchy/blob/3e3a8859a94755cc0b7d2de5f189a3de7ccb62e7/src/Watchy.cpp#L69)

These changes are backward-compatible: if a watch face does not implement `handleButtonPress`, then there will be no functional changes with any watch face.

In addition, calling `Watchy::handleButtonPress()` from the user's own `handleButtonPress` function will make the watch perform its regular functions with the original buttons.  However, if the user would like to have their own menu, for example, they don't need to always call `Watchy::handleButtonPress()`.  This could look like this:

```cpp
bool inMyMenu = false;

void WatchyKeen::handleButtonPress() {
  if (!inMyMenu && buttonPressed == myMenuButton) {
    inMyMenu = true;
  }

  if (inMyMenu) {
    // perform your own tasks here
    // set inMyMenu to false when you're done
  } else {
    Watchy::handleButtonPress();
  }
}
```

Other examples of how this could be implemented:

- Make the up and down buttons turn lights on and off in your home
- Kick off a non-deep-sleep routine, like a watch face-specific menu or other feature
- Change the watch backgrounds, if multiple are available on a watch face