### PR TITLE
PCF8563: Call rtc_pcf.getDateTime in WatchyRTC::read

### DIFF
--- a/src/WatchyRTC.cpp
+++ b/src/WatchyRTC.cpp
@@ -47,6 +47,7 @@ void WatchyRTC::read(tmElements_t &tm) {
   if (rtcType == DS3231) {
     rtc_ds.read(tm);
   } else {
+    rtc_pcf.getDateTime();
     tm.Year  = y2kYearToTm(rtc_pcf.getYear());
     tm.Month = rtc_pcf.getMonth();
     tm.Day   = rtc_pcf.getDay();


### PR DESCRIPTION
Fixes #128 as noted by @neaket