### PR TITLE
Fix up and down buttons being reversed when setting time

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -369,7 +369,7 @@ void Watchy::setTime() {
 
     blink = 1 - blink;
 
-    if (digitalRead(DOWN_BTN_PIN) == 1) {
+    if (digitalRead(UP_BTN_PIN) == 1) {
       blink = 1;
       switch (setIndex) {
       case SET_HOUR:
@@ -392,7 +392,7 @@ void Watchy::setTime() {
       }
     }
 
-    if (digitalRead(UP_BTN_PIN) == 1) {
+    if (digitalRead(DOWN_BTN_PIN) == 1) {
       blink = 1;
       switch (setIndex) {
       case SET_HOUR:


### PR DESCRIPTION
This commit switches what the up/down buttons do when setting the time.

Right now it seems like the up and down button behavior is reversed. The up button is decreases the number and the down button increases it which is confusing.