### PR TITLE
SPI set to 20MHz

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -20,6 +20,7 @@ void Watchy::init(String datetime) {
   RTC.init();
 
   // Init the display here for all cases, if unused, it will do nothing
+  display.epd2.selectSPI(SPI, SPISettings(20000000, MSBFIRST, SPI_MODE0)); // Set SPI to 20Mhz (default is 4Mhz)
   display.init(0, displayFullInit, 10,
                true); // 10ms by spec, and fast pulldown reset
   display.epd2.setBusyCallback(displayBusyCallback);


### PR DESCRIPTION
* Speed up SPI transfer to the display
  by using 20Mhz instead of default 4Mhz
  This saves around 16ms = 1.5mJ/refresh
  or 2160mJ/day = 0.6mWh/day = 0.2mAh/day
  (890ms -> 874ms)