### PR TITLE
Set GMT offset from weatherdata

### DIFF
--- a/examples/WatchFaces/7_SEG/settings.h
+++ b/examples/WatchFaces/7_SEG/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/Basic/settings.h
+++ b/examples/WatchFaces/Basic/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/DOS/settings.h
+++ b/examples/WatchFaces/DOS/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/MacPaint/settings.h
+++ b/examples/WatchFaces/MacPaint/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/Pokemon/settings.h
+++ b/examples/WatchFaces/Pokemon/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/StarryHorizon/settings.h
+++ b/examples/WatchFaces/StarryHorizon/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/examples/WatchFaces/Tetris/settings.h
+++ b/examples/WatchFaces/Tetris/settings.h
@@ -10,7 +10,7 @@
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
 //NTP Settings
 #define NTP_SERVER "pool.ntp.org"
-#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT
+#define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
     CITY_ID,

--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -622,6 +622,7 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
             responseObject["weather"][0]["main"];
         // sync NTP during weather API call and use timezone of city
         gmtOffset = int(responseObject["timezone"]);
+        syncNTP(gmtOffset);
       } else {
         // http error
       }


### PR DESCRIPTION
This extends the recent changes to get DST from the weather data to also persist the information in `gmtOffset`, so the gmtOffset can also be determined automatically.