### PR TITLE
fixed compilation error: ambiguous overload for 'operator='

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -617,7 +617,7 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
         currentWeather.weatherConditionCode =
             int(responseObject["weather"][0]["id"]);
         currentWeather.weatherDescription =
-            responseObject["weather"][0]["main"];
+	  JSONVar::stringify(responseObject["weather"][0]["main"]);
         // sync NTP during weather API call and use timezone of city
         syncNTP(long(responseObject["timezone"]));
       } else {


### PR DESCRIPTION
.pio/libdeps/watchy/Watchy/src/Watchy.cpp: In member function 'weatherData Watchy::getWeatherData(String, String, String, String, String, uint8_t)': .pio/libdeps/watchy/Watchy/src/Watchy.cpp:620:48: error: ambiguous overload for 'operator=' (operand types are 'String' and 'JSONVar')
             responseObject["weather"][0]["main"];
                                                ^
In file included from /home/krupp/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:166,
                 from .pio/libdeps/watchy/Watchy/src/Watchy.h:4,
                 from .pio/libdeps/watchy/Watchy/src/Watchy.cpp:1:
/home/build/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.h:102:18: note: candidate: 'String& String::operator=(const String&)'
         String & operator =(const String &rhs);
                  ^~~~~~~~
/home/build/.platformio/packages/framework-arduinoespressif32/cores/esp32/WString.h:103:18: note: candidate: 'String& String::operator=(const char*)'
         String & operator =(const char *cstr);
                  ^~~~~~~~