### PR TITLE
Keep track on weather source

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -618,6 +618,7 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
             int(responseObject["weather"][0]["id"]);
         currentWeather.weatherDescription =
 	  JSONVar::stringify(responseObject["weather"][0]["main"]);
+	    currentWeather.external = true;
         // sync NTP during weather API call and use timezone of city
         syncNTP(long(responseObject["timezone"]));
       } else {
@@ -634,6 +635,7 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
       }
       currentWeather.temperature          = temperature;
       currentWeather.weatherConditionCode = 800;
+      currentWeather.external             = false;
     }
     weatherIntervalCounter = 0;
   } else {

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -22,6 +22,7 @@ typedef struct weatherData {
   int16_t weatherConditionCode;
   bool isMetric;
   String weatherDescription;
+  bool external;
 } weatherData;
 
 typedef struct watchySettings {


### PR DESCRIPTION
When the weather is received over wifi, the code falls back to the internal temperature sensor.

To allow watch faces to make this difference clear (e.g. don't show the temperature, use a "house" icon instead of a weather icon, ...) a new boolean field `external` was added to the weather data struct.