### PR TITLE
Allow button press overrides

### DIFF
--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -56,7 +56,7 @@ public:
   float getBatteryVoltage();
   void vibMotor(uint8_t intervalMs = 100, uint8_t length = 20);
 
-  void handleButtonPress();
+  virtual void handleButtonPress();
   void showMenu(byte menuIndex, bool partialRefresh);
   void showFastMenu(byte menuIndex);
   void showAbout();


### PR DESCRIPTION
This PR allows watch faces to override the button press handler. This means that a face can give different functionality to certain buttons, or leave others unchanged.

Add to `.h`:

```
class Face : public Watchy{
    using Watchy::Watchy;
    public:
        void drawWatchFace();
        // ...
        virtual void handleButtonPress();
};
```

```
void Face::handleButtonPress() {
  if (guiState == WATCHFACE_STATE) {
    uint64_t wakeupBit = esp_sleep_get_ext1_wakeup_status();
    if (wakeupBit & UP_BTN_MASK) {
      // Do something special
      RTC.read(currentTime);
      showWatchFace(false);
      return;
    }
    if (wakeupBit & DOWN_BTN_MASK) {
      // Do something else special
      RTC.read(currentTime);
      showWatchFace(false);
      return;
    }
    if (wakeupBit & BACK_BTN_MASK) {
      // if (something special) {
      //   restore_to_normal();
      //   return;
      // }
      Watchy::handleButtonPress();
      return;
    }
    if (wakeupBit & MENU_BTN_MASK) {
      Watchy::handleButtonPress();
      return;
    }
  } else {Watchy::handleButtonPress();}
  return;
}
```