### PR TITLE
Reset weather counter on Wifi connection

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -828,6 +828,7 @@ void Watchy::setupWifi() {
     display.println(WiFi.SSID());
 		display.println("Local IP:");
 		display.println(WiFi.localIP());
+    weatherIntervalCounter = -1; // Reset to force weather to be read again
   }
   display.display(false); // full refresh
   // turn off radios


### PR DESCRIPTION
Fix to make sure after connecting to a Wifi point that the next call to getWeatherData will actually attempt to connect to the API endpoint.

Currently the weatherIntervalCounter will increment every time getWeatherData is called, WiFi connected or not. So without this fix if getWeatherData is called, after connecting to a new WiFi it will skip calling the API until the WEATHER_UPDATE_INTERVAL (30 minutes by default) has passed. This leads to a delay in the first display of weather data.

Please let me know if you need some more details.