### PR TITLE
Switch from CityID to Lat an Lon, expose sunrise and sunset

### DIFF
--- a/examples/WatchFaces/7_SEG/settings.h
+++ b/examples/WatchFaces/7_SEG/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/Basic/settings.h
+++ b/examples/WatchFaces/Basic/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/DOS/settings.h
+++ b/examples/WatchFaces/DOS/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/MacPaint/settings.h
+++ b/examples/WatchFaces/MacPaint/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/Mario/settings.h
+++ b/examples/WatchFaces/Mario/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/Pokemon/settings.h
+++ b/examples/WatchFaces/Pokemon/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/StarryHorizon/settings.h
+++ b/examples/WatchFaces/StarryHorizon/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/examples/WatchFaces/Tetris/settings.h
+++ b/examples/WatchFaces/Tetris/settings.h
@@ -2,9 +2,10 @@
 #define SETTINGS_H
 
 //Weather Settings
-#define CITY_ID "5128581" //New York City https://openweathermap.org/current#cityid
+#define LAT "45.793411" // New York City, Looked up on https://www.latlong.net/
+#define LON "-97.751968"
 #define OPENWEATHERMAP_APIKEY "f058fe1cad2afe8e2ddc5d063a64cecb" //use your own API key :)
-#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?id=" //open weather api
+#define OPENWEATHERMAP_URL "http://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&lang={lang}&units={units}&appid={apiKey}" //open weather api
 #define TEMP_UNIT "metric" //metric = Celsius , imperial = Fahrenheit
 #define TEMP_LANG "en"
 #define WEATHER_UPDATE_INTERVAL 30 //must be greater than 5, measured in minutes
@@ -13,7 +14,8 @@
 #define GMT_OFFSET_SEC 3600 * -5 //New York is UTC -5 EST, -4 EDT, will be overwritten by weather data
 
 watchySettings settings{
-    .cityID = CITY_ID,
+    .lat = LAT,
+    .lon = LON,
     .weatherAPIKey = OPENWEATHERMAP_APIKEY,
     .weatherURL = OPENWEATHERMAP_URL,
     .weatherUnit = TEMP_UNIT,

--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -626,12 +626,12 @@ void Watchy::drawWatchFace() {
 }
 
 weatherData Watchy::getWeatherData() {
-  return getWeatherData(settings.cityID, settings.weatherUnit,
+  return getWeatherData(settings.lat, settings.lon, settings.weatherUnit,
                         settings.weatherLang, settings.weatherURL,
                         settings.weatherAPIKey, settings.weatherUpdateInterval);
 }
 
-weatherData Watchy::getWeatherData(String cityID, String units, String lang,
+weatherData Watchy::getWeatherData(String lat, String lon, String units, String lang,
                                    String url, String apiKey,
                                    uint8_t updateInterval) {
   currentWeather.isMetric = units == String("metric");
@@ -644,9 +644,12 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
     if (connectWiFi()) {
       HTTPClient http; // Use Weather API for live data if WiFi is connected
       http.setConnectTimeout(3000); // 3 second max timeout
-      String weatherQueryURL = url + cityID + String("&units=") + units +
-                               String("&lang=") + lang + String("&appid=") +
-                               apiKey;
+      String weatherQueryURL = url;
+      weatherQueryURL.replace("{lat}", lat);
+      weatherQueryURL.replace("{lon}", lon);
+      weatherQueryURL.replace("{units}", units);
+      weatherQueryURL.replace("{lang}", lang);
+      weatherQueryURL.replace("{apiKey}", apiKey);
       http.begin(weatherQueryURL.c_str());
       int httpResponseCode = http.GET();
       if (httpResponseCode == 200) {
@@ -656,9 +659,11 @@ weatherData Watchy::getWeatherData(String cityID, String units, String lang,
         currentWeather.weatherConditionCode =
             int(responseObject["weather"][0]["id"]);
         currentWeather.weatherDescription =
-	  JSONVar::stringify(responseObject["weather"][0]["main"]);
+		JSONVar::stringify(responseObject["weather"][0]["main"]);
 	    currentWeather.external = true;
-        // sync NTP during weather API call and use timezone of city
+		breakTime((time_t)(int)responseObject["sys"]["sunrise"], currentWeather.sunrise);
+		breakTime((time_t)(int)responseObject["sys"]["sunset"], currentWeather.sunset);
+        // sync NTP during weather API call and use timezone of lat & lon
         gmtOffset = int(responseObject["timezone"]);
         syncNTP(gmtOffset);
       } else {

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -23,11 +23,14 @@ typedef struct weatherData {
   bool isMetric;
   String weatherDescription;
   bool external;
+  tmElements_t sunrise;
+  tmElements_t sunset;
 } weatherData;
 
 typedef struct watchySettings {
   // Weather Settings
-  String cityID;
+  String lat;
+  String lon;
   String weatherAPIKey;
   String weatherURL;
   String weatherUnit;
@@ -70,7 +73,7 @@ public:
   void setupWifi();
   bool connectWiFi();
   weatherData getWeatherData();
-  weatherData getWeatherData(String cityID, String units, String lang,
+  weatherData getWeatherData(String lat, String lon, String units, String lang,
                              String url, String apiKey, uint8_t updateInterval);
   void updateFWBegin();
 


### PR DESCRIPTION
#232 mentions settings.gmtOffset should not be seconds, but it sure looks like it's seconds in the examples.

It also mentions OpenWeatherMap API changes. This
- updates the API call (less concat, more replace)
- exposes settings.lat, settings.lon, settings.sunrise, settings.sunset for more options
- updates the samples