### PR TITLE
Display upgrades

### DIFF
--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -441,6 +441,23 @@ void WatchyDisplay::_InitDisplay()
   _setPartialRamArea(0, 0, WIDTH, HEIGHT);
 }
 
+void WatchyDisplay::_reset()
+{
+  // Call default method if not configured the same way
+  if (_rst < 0 || !_pulldown_rst_mode) {
+    GxEPD2_EPD::_reset();
+    return;
+  }
+
+  digitalWrite(_rst, LOW);
+  pinMode(_rst, OUTPUT);
+  delay(_reset_duration);
+  pinMode(_rst, INPUT_PULLUP);
+  // Tested calling _powerOn() inmediately, and works ok, no need to sleep
+  // delay(_reset_duration > 10 ? _reset_duration : 0);
+  _hibernating = false;
+}
+
 void WatchyDisplay::_Init_Full()
 {
   _InitDisplay();

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -38,6 +38,15 @@ void WatchyDisplay::initWatchy() {
   init(0, displayFullInit, 2, true);
 }
 
+void WatchyDisplay::setDarkBorder(bool dark) {
+  if (_hibernating) return;
+  darkBorder = dark;
+  _startTransfer();
+  _transferCommand(0x3C); // BorderWavefrom
+  _transfer(dark ? 0x02 : 0x05);
+  _endTransfer();
+}
+
 void WatchyDisplay::clearScreen(uint8_t value)
 {
   writeScreenBuffer(value);
@@ -394,11 +403,11 @@ void WatchyDisplay::_InitDisplay()
     _transfer(0x00); // Duration of phases, Default 0xF = 0b00 11 11 (40ms Phase 1/2, 10ms Phase 3)
   }
 
-  _transferCommand(0x3C); // BorderWavefrom
-  _transfer(darkBorder ? 0x02 : 0x05);
   _transferCommand(0x18); // Read built-in temperature sensor
   _transfer(0x80);
   _endTransfer();
+
+  setDarkBorder(darkBorder);
 
   _setPartialRamArea(0, 0, WIDTH, HEIGHT);
 }

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -16,10 +16,19 @@
 
 #include "Display.h"
 
-WatchyDisplay::WatchyDisplay(int16_t cs, int16_t dc, int16_t rst, int16_t busy) :
-  GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+#include "config.h"
+void WatchyDisplay::busyCallback(const void *) {
+  gpio_wakeup_enable((gpio_num_t)DISPLAY_BUSY, GPIO_INTR_LOW_LEVEL);
+  esp_sleep_enable_gpio_wakeup();
+  esp_light_sleep_start();
+}
+
+WatchyDisplay::WatchyDisplay() :
+  GxEPD2_EPD(DISPLAY_CS, DISPLAY_DC, DISPLAY_RES, DISPLAY_BUSY, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {
+  // Watchy default initialization
   selectSPI(SPI, SPISettings(20000000, MSBFIRST, SPI_MODE0)); // Set SPI to 20Mhz (default is 4Mhz)
+  setBusyCallback(busyCallback);
 }
 
 void WatchyDisplay::clearScreen(uint8_t value)

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -372,8 +372,10 @@ void WatchyDisplay::_PowerOff()
 void WatchyDisplay::_InitDisplay()
 {
   if (_hibernating) _reset();
-  _writeCommand(0x12); // soft reset
-  _waitWhileBusy("_SoftReset", 10); // 10ms max according to specs
+
+  // No need to soft reset, the Display goes to same state after hard reset
+  // _writeCommand(0x12); // soft reset
+  // _waitWhileBusy("_SoftReset", 10); // 10ms max according to specs*/
 
   _startTransfer();
   _transferCommand(0x01); // Driver output control

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -382,6 +382,18 @@ void WatchyDisplay::_InitDisplay()
   _transfer(0xC7);
   _transfer(0x00);
   _transfer(0x00);
+
+  if (reduceBoosterTime) {
+    // SSD1675B controller datasheet
+    _transferCommand(0x0C); // BOOSTER_SOFT_START_CONTROL
+    // Set the driving strength of GDR for all phases to maximun 0b111 -> 0xF
+    // Set the minimum off time of GDR to minimum 0x4 (values below sould be same)
+    _transfer(0xF4); // Phase1 Default value 0x8B
+    _transfer(0xF4); // Phase2 Default value 0x9C
+    _transfer(0xF4); // Phase3 Default value 0x96
+    _transfer(0x00); // Duration of phases, Default 0xF = 0b00 11 11 (40ms Phase 1/2, 10ms Phase 3)
+  }
+
   _transferCommand(0x3C); // BorderWavefrom
   _transfer(darkBorder ? 0x02 : 0x05);
   _transferCommand(0x18); // Read built-in temperature sensor

--- a/src/Display.cpp
+++ b/src/Display.cpp
@@ -15,8 +15,10 @@
 // Link: https://github.com/sqfmi/Watchy
 
 #include "Display.h"
-
 #include "config.h"
+
+RTC_DATA_ATTR bool displayFullInit       = true;
+
 void WatchyDisplay::busyCallback(const void *) {
   gpio_wakeup_enable((gpio_num_t)DISPLAY_BUSY, GPIO_INTR_LOW_LEVEL);
   esp_sleep_enable_gpio_wakeup();
@@ -26,9 +28,14 @@ void WatchyDisplay::busyCallback(const void *) {
 WatchyDisplay::WatchyDisplay() :
   GxEPD2_EPD(DISPLAY_CS, DISPLAY_DC, DISPLAY_RES, DISPLAY_BUSY, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {
-  // Watchy default initialization
-  selectSPI(SPI, SPISettings(20000000, MSBFIRST, SPI_MODE0)); // Set SPI to 20Mhz (default is 4Mhz)
+  // Setup callback and SPI by default
+  selectSPI(SPI, SPISettings(20000000, MSBFIRST, SPI_MODE0));
   setBusyCallback(busyCallback);
+}
+
+void WatchyDisplay::initWatchy() {
+  // Watchy default initialization
+  init(0, displayFullInit, 2, true);
 }
 
 void WatchyDisplay::clearScreen(uint8_t value)
@@ -404,6 +411,7 @@ void WatchyDisplay::_Update_Full()
   _transferCommand(0x20);
   _endTransfer();
   _waitWhileBusy("_Update_Full", full_refresh_time);
+  displayFullInit = false;
 }
 
 void WatchyDisplay::_Update_Part()

--- a/src/Display.h
+++ b/src/Display.h
@@ -91,5 +91,7 @@ class WatchyDisplay : public GxEPD2_EPD
     void _Update_Full();
     void _Update_Part();
 
+    void _reset();
+
     void _transferCommand(uint8_t command);
 };

--- a/src/Display.h
+++ b/src/Display.h
@@ -35,6 +35,7 @@ class WatchyDisplay : public GxEPD2_EPD
     static const uint16_t partial_refresh_time = 500; // ms, e.g. 457282us
     // constructor
     WatchyDisplay();
+    void initWatchy();
     static void busyCallback(const void *);
     // methods (virtual)
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen

--- a/src/Display.h
+++ b/src/Display.h
@@ -71,6 +71,8 @@ class WatchyDisplay : public GxEPD2_EPD
     void hibernate(); // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
 
     bool darkBorder = false; // adds a dark border outside the normal screen area
+
+    static constexpr bool reduceBoosterTime = true; // Saves ~200ms
   private:
     void _writeScreenBuffer(uint8_t command, uint8_t value);
     void _writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);

--- a/src/Display.h
+++ b/src/Display.h
@@ -36,6 +36,7 @@ class WatchyDisplay : public GxEPD2_EPD
     // constructor
     WatchyDisplay();
     void initWatchy();
+    void setDarkBorder(bool darkBorder);
     static void busyCallback(const void *);
     // methods (virtual)
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen

--- a/src/Display.h
+++ b/src/Display.h
@@ -34,7 +34,8 @@ class WatchyDisplay : public GxEPD2_EPD
     static const uint16_t full_refresh_time = 2600; // ms, e.g. 2509602us
     static const uint16_t partial_refresh_time = 500; // ms, e.g. 457282us
     // constructor
-    WatchyDisplay(int16_t cs, int16_t dc, int16_t rst, int16_t busy);
+    WatchyDisplay();
+    static void busyCallback(const void *);
     // methods (virtual)
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
     void clearScreen(uint8_t value = 0xFF); // init controller memory and screen (default white)

--- a/src/Display.h
+++ b/src/Display.h
@@ -37,6 +37,9 @@ class WatchyDisplay : public GxEPD2_EPD
     WatchyDisplay();
     void initWatchy();
     void setDarkBorder(bool darkBorder);
+    void asyncPowerOn();
+    void _PowerOnAsync();
+    bool waitingPowerOn = false;
     static void busyCallback(const void *);
     // methods (virtual)
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen

--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -594,6 +594,8 @@ void Watchy::showAccelerometer() {
 
 void Watchy::showWatchFace(bool partialRefresh) {
   display.setFullWindow();
+  // At this point it is sure we are going to update
+  display.epd2.asyncPowerOn();
   drawWatchFace();
   display.display(partialRefresh); // partial refresh
   guiState = WATCHFACE_STATE;

--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -2,7 +2,7 @@
 
 WatchyRTC Watchy::RTC;
 GxEPD2_BW<WatchyDisplay, WatchyDisplay::HEIGHT> Watchy::display(
-    WatchyDisplay(DISPLAY_CS, DISPLAY_DC, DISPLAY_RES, DISPLAY_BUSY));
+    WatchyDisplay{});
 
 RTC_DATA_ATTR int guiState;
 RTC_DATA_ATTR int menuIndex;
@@ -23,10 +23,8 @@ void Watchy::init(String datetime) {
   RTC.init();
 
   // Init the display here for all cases, if unused, it will do nothing
-  display.epd2.selectSPI(SPI, SPISettings(20000000, MSBFIRST, SPI_MODE0)); // Set SPI to 20Mhz (default is 4Mhz)
   display.init(0, displayFullInit, 10,
                true); // 10ms by spec, and fast pulldown reset
-  display.epd2.setBusyCallback(displayBusyCallback);
 
   switch (wakeup_reason) {
   case ESP_SLEEP_WAKEUP_EXT0: // RTC Alarm
@@ -67,13 +65,6 @@ void Watchy::init(String datetime) {
   }
   deepSleep();
 }
-
-void Watchy::displayBusyCallback(const void *) {
-  gpio_wakeup_enable((gpio_num_t)DISPLAY_BUSY, GPIO_INTR_LOW_LEVEL);
-  esp_sleep_enable_gpio_wakeup();
-  esp_light_sleep_start();
-}
-
 void Watchy::deepSleep() {
   display.hibernate();
   if (displayFullInit) // For some reason, seems to be enabled on first boot
@@ -834,8 +825,8 @@ void Watchy::setupWifi() {
   // turn off radios
   WiFi.mode(WIFI_OFF);
   btStop();
-  display.epd2.setBusyCallback(displayBusyCallback); // enable lightsleep on
-                                                     // busy
+  // enable lightsleep on busy
+  display.epd2.setBusyCallback(WatchyDisplay::busyCallback);
   guiState = APP_STATE;
 }
 

--- a/src/Watchy.h
+++ b/src/Watchy.h
@@ -51,7 +51,6 @@ public:
   explicit Watchy(const watchySettings &s) : settings(s) {} // constructor
   void init(String datetime = "");
   void deepSleep();
-  static void displayBusyCallback(const void *);
   float getBatteryVoltage();
   void vibMotor(uint8_t intervalMs = 100, uint8_t length = 20);
 


### PR DESCRIPTION
This PR has commits that affect the display in these aspects:
- Moves the display init/config/callback from Watchy.cpp to Display.cpp (Where it should be imo)
- Move the init()/callback to the constructor, no need to call it manually
- Allows the darkborder feature to be changed on demand using the function, not only on init()
- Allows to asyncPowerOn() the display, to prepare the HW ahead of time if it will render [-16ms]
- Remove redundant soft reset after hard reset [-6ms]
- Reduce init() reset time from 10ms -> 2ms (possibly unsafe? not sure) [-8ms]
- Change the booster configuration to soft start slower (possibly unsafe? not sure) [-220ms]

In all, this change makes display update take 250ms less (650ms -> 400ms).
Not all of the time saved is power saved, since some of that time the CPU was in light sleep already.
I theoretically computed that the power reduced ~30% (~9mA * 650ms = 6mW -> ~10mA * 400ms = 4mW)

I would value that this change is tested before merging, specially the changes:
- init() 10ms -> 2ms time
- Booster configuration