### PR TITLE
Improve portability between different versions of Arduino-ESP32.

### DIFF
--- a/src/BLE.cpp
+++ b/src/BLE.cpp
@@ -38,7 +38,7 @@ public:
 };
 
 void otaCallback::onWrite(BLECharacteristic *pCharacteristic) {
-  String rxData = pCharacteristic->getValue();
+  auto rxData = pCharacteristic->getValue();
   if (!updateFlag) { // If it's the first packet of OTA since bootup, begin OTA
     // Serial.println("Begin FW Update");
     esp_ota_begin(esp_ota_get_next_update_partition(NULL), OTA_SIZE_UNKNOWN,


### PR DESCRIPTION
The `BLECharacteristic::getValue()` method returns `std::string` in older versions of Arduino core for the ESP32 and `String` in newer versions.

However, the return value is used in a way that both classes support: using only `length()` and `c_str()` methods.

Hence, replacing explicit type name with auto keyword makes the code compatible with older and newer versions.