### PR TITLE
turn off wifi after NTP sync

### DIFF
--- a/src/Watchy.cpp
+++ b/src/Watchy.cpp
@@ -1118,6 +1118,8 @@ void Watchy::showSyncNTP() {
     } else {
       display.println("NTP Sync Failed");
     }
+    WiFi.mode(WIFI_OFF);
+    btStop();
   } else {
     display.println("WiFi Not Configured");
   }


### PR DESCRIPTION
When the NTP sync is run manually via the menu, the wifi is not turned off after NTP sync.